### PR TITLE
feat: 環境ごとに挙動を切り替えられる様に環境変数を使用する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: run
 run:
-	flutter run
+	flutter run --dart-define=PORT=8080 --dart-define=HOST='localhost'
 
 .PHONY: gen_proto
 gen_proto:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 ## About
 
 gRPC を用いてリアルタイムチャットアプリを作ってみる(app 側)
+
+## Setup
+
+- iPhone のシミュレータを起動する
+
+```
+$ open -a Simulator
+```
+
+- アプリを起動する
+
+```
+$ make run
+```

--- a/lib/environment/index.dart
+++ b/lib/environment/index.dart
@@ -1,0 +1,7 @@
+class Environment {
+  // singleton
+  Environment._();
+
+  static const PORT = int.fromEnvironment('PORT', defaultValue: 8080);
+  static const HOST = String.fromEnvironment('HOST', defaultValue: 'localhost');
+}

--- a/lib/service/common.dart
+++ b/lib/service/common.dart
@@ -1,11 +1,12 @@
 import 'package:grpc/grpc.dart';
 
+import '../environment/index.dart';
 import '../proto/pb/room.pbgrpc.dart';
 
 ClientChannel createChannel() {
   return ClientChannel(
-    'localhost',
-    port: 8080,
+    Environment.HOST,
+    port: Environment.PORT,
     options: const ChannelOptions(
       credentials: ChannelCredentials.insecure(),
     ),


### PR DESCRIPTION
## About
環境ごとに挙動を切り替えられる様に環境変数を使用
## Background
本番環境とデバッグ環境で挙動を分けたかった
## Details
- Flutter1.7から採用された[--dart-define](https://github.com/wiredashio/wiredash-sdk/blob/f90f346e4a6cff9a08d5ec1a9ab12c887160a6c0/lib/src/common/utils/build_info.dart#L15)で環境変数を渡す
- シングルトンで環境変数クラス`environment`を作成し、そこから変数を参照する
- 現在はport番号とhostのみを伝搬
- Makefileに起動処理記述
